### PR TITLE
Versiones de las librerias actualizadas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 certifi==2018.11.29
-Click==7.0
+Click==8.0
 dnspython==1.16.0
-Flask==1.0.2
-itsdangerous==1.1.0
-Jinja2==2.10
-MarkupSafe==1.1.0
+Flask==2.1.1
+itsdangerous==2.0
+Jinja2==3.0
+MarkupSafe==2.0.0rc2
 pymongo==3.7.2
-Werkzeug==0.14.1
+Werkzeug==2.0


### PR DESCRIPTION
Se actualizaron las versiones de las librerias a sus versiones
mas recientes, las anteriores versiones generaban errores en
python 3.10.

En versiones anteriores a python 3.10 una de sus librerias
se llamaba "collections" pero ahora en python 3.10 es "collections.abc".

Las nuevas versiones de las librerias que aqui se usan importan la
libreria de python como "_collections_abc".